### PR TITLE
Forgot Password Panel

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,10 +6,12 @@ import Signup from './components/General/Signup';
 import Profile from './components/Profile'; // only for testing purpose
 import NormalizeStyle from './Styles/bases/Normalize';
 import 'semantic-ui-css/semantic.min.css';
+import ForgotPassword from './components/General/ForgotPassword';
 
 class App extends React.Component {
   state = {
-    isLoginOpen: false
+    isLoginOpen: false,
+    isForgotPasswordOpen: false
   };
 
   openLoginPanel = () => {
@@ -27,6 +29,18 @@ class App extends React.Component {
   closeSignupPanel = () => {
     this.setState({ isSignupOpen: false });
   };
+
+  openForgotPasswordPanel = () => {
+    this.setState({
+      isForgotPasswordOpen: true,
+      isLoginOpen: false
+    });
+  };
+
+  closeForgotPasswordPanel = () => {
+    this.setState({ isForgotPasswordOpen: false });
+  };
+
   render() {
     return (
       <div className="App">
@@ -34,18 +48,29 @@ class App extends React.Component {
         <BrowserRouter>
           <div>
             <Navbar openLoginPanel={this.openLoginPanel} />
+
             {this.state.isLoginOpen ? (
               <Login
                 closeLoginPanel={this.closeLoginPanel}
                 openSignupPanel={this.openSignupPanel}
+                openForgotPasswordPanel={this.openForgotPasswordPanel}
               />
             ) : null}
+
             {this.state.isSignupOpen ? (
               <Signup
                 closeSignupPanel={this.closeSignupPanel}
                 openLoginPanel={this.openLoginPanel}
               />
             ) : null}
+
+            {this.state.isForgotPasswordOpen ? (
+              <ForgotPassword
+                closeForgotPasswordPanel={this.closeForgotPasswordPanel}
+                openForgotPasswordPanel={this.openForgotPasswordPanel}
+              />
+            ) : null}
+
             <Switch>
               <Route
                 exact

--- a/client/src/components/General/ForgotPassword/Component.jsx
+++ b/client/src/components/General/ForgotPassword/Component.jsx
@@ -1,0 +1,109 @@
+import React, { Component } from 'react';
+import { Col, Row } from '../../../lib/Grid';
+import Button from '../../../lib/Button';
+import TextField from '../../../lib/TextField';
+import FieldError from '../../../lib/Feedback/FieldError';
+import { Margin } from '../../../Styles/utils';
+import { Logo, Brand } from '../../../Styles/bases/Identity';
+import { Form, Field } from 'react-final-form';
+import {
+  FullPageFilter,
+  FullPageLayer,
+  LoginContainer,
+  LoginTitleWrapper
+} from './styled';
+
+import {
+  composeValidators,
+  emailFormat,
+  emailRequired,
+} from '../../../utils/validationRules';
+
+import { withRouter } from 'react-router-dom';
+
+class ForgotPassword extends Component {
+  state = {
+    emailAddress: '',
+  };
+
+  onSubmit = ({ email }) => {
+    this.setState({ emailAddress: email });
+  };
+
+  handleChange = ({ target: { value } }) => {
+    this.setState({
+      value
+    });
+  };
+
+  render() {
+    return (
+      <FullPageLayer>
+        <FullPageFilter
+          onClick={() => {
+            this.props.closeForgotPasswordPanel();
+          }}
+        />
+
+        <LoginContainer>
+          <LoginTitleWrapper>
+            <Logo />
+            <Brand>Harvesthru</Brand>
+          </LoginTitleWrapper>
+
+          <Margin top={32} bottom={32}>
+            <p>We will send you a link to reset your password!</p>
+          </Margin>
+
+          <Form
+            onSubmit={this.onSubmit}
+            render={({ handleSubmit }) => (
+              <form onSubmit={handleSubmit}>
+                <Margin top={32} bottom={32}>
+                  <Row justify="center">
+                    <Col xs={12} lg={12}>
+                      <Field
+                        name="email"
+                        type="text"
+                        validate={composeValidators(emailFormat, emailRequired)}
+                        render={({ input, meta }) => (
+                          <React.Fragment>
+                            <TextField
+                              label="Email Address"
+                              placeholder="You email address"
+                              autoFocus={false}
+                              {...input}
+                              {...meta}
+                            />
+                            {meta.touched && <FieldError>{meta.error}</FieldError>}
+                          </React.Fragment>
+                        )}
+                      />
+                    </Col>
+                  </Row>
+                </Margin>
+                <Margin top={32} bottom={32}>
+                  <Row justify="center">
+                    <Col xs={12} lg={12}>
+                      <Button
+                        id="loginButton"
+                        testid="loginButton"
+                        type="submit"
+                        colorType="green"
+                        block
+                      >
+                        Reset Password
+                      </Button>
+                    </Col>
+                  </Row>
+                </Margin>
+              </form>
+            )}
+          />
+        </LoginContainer>
+      </FullPageLayer>
+    );
+  }
+}
+
+export default withRouter(ForgotPassword);

--- a/client/src/components/General/ForgotPassword/index.jsx
+++ b/client/src/components/General/ForgotPassword/index.jsx
@@ -1,0 +1,3 @@
+import ForgotPassword from "./Component";
+
+export default ForgotPassword;

--- a/client/src/components/General/ForgotPassword/styled.jsx
+++ b/client/src/components/General/ForgotPassword/styled.jsx
@@ -43,6 +43,7 @@ const FormHelperLink = styled.div`
 
 // const fadeInDownAnimation = keyframes`${fadeIn}`;
 const LoginContainer = styled.div`
+  font-family: Quicksand;
   width: 450px;
   height: 640px;
   position: absolute;

--- a/client/src/components/General/ForgotPassword/styled.jsx
+++ b/client/src/components/General/ForgotPassword/styled.jsx
@@ -1,0 +1,89 @@
+import Color from '../../../Styles/bases/Color';
+import styled from 'styled-components';
+
+const FullPageLayer = styled.div`
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+// const fadeInAnimation = keyframes`${fadeIn}`;
+const FullPageFilter = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  ${'' /* animation: 0.8s ${fadeInAnimation}; */}
+`;
+
+const FormHelperLink = styled.div`
+  font-family: Quicksand;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: bold;
+  line-height: 17px;
+  text-align: right;
+  cursor: pointer;
+  a {
+    color: ${Color.grey};
+    cursor: pointer;
+    &:visited {
+      color: ${Color.darkGrey};
+    }
+    &:hover {
+      color: ${Color.darkGrey};
+    }
+  }
+`;
+
+// const fadeInDownAnimation = keyframes`${fadeIn}`;
+const LoginContainer = styled.div`
+  width: 450px;
+  height: 640px;
+  position: absolute;
+  padding: 50px 20px;
+  text-align: center;
+  border-radius: 8px;
+  opacity: 0.95;
+  background: white;
+  ${'' /* animation: 0.8s ${fadeInDownAnimation}; */}
+`;
+
+const LoginWrapper = styled.div`
+  display: flex;
+  align: center;
+  justify: center;
+`;
+
+const LoginTitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const dividerStyle = {
+  color: '#6C6C6C',
+  fontFamily: 'Quicksand',
+  fontStyle: 'normal',
+  fontWeight: 'bold',
+  fontSize: '13px',
+  lineHeight: '10px',
+  textTransform: 'lowercase',
+  margin: '2px'
+};
+export {
+  dividerStyle,
+  FullPageLayer,
+  // fadeInAnimation,
+  FullPageFilter,
+  // fadeInDownAnimation,
+  FormHelperLink,
+  LoginContainer,
+  LoginTitleWrapper,
+  LoginWrapper
+};

--- a/client/src/components/General/Login/Component.jsx
+++ b/client/src/components/General/Login/Component.jsx
@@ -122,8 +122,11 @@ class Login extends Component {
                             </React.Fragment>
                           )}
                         />
-                        <FormHelperLink>
-                          <Link to={PATH_FORGOT_PASSWORD}>Forgot your password?</Link>
+                        <FormHelperLink onClick={() => {
+                            this.props.openForgotPasswordPanel();
+                          }}
+                        >
+                          Forgot your password?
                         </FormHelperLink>
                       </Col>
                       <Row justify="center">


### PR DESCRIPTION
Still currently making more polishes, but I want to get the initial implementation out there for continuous feedback.

Asking @wmchin to check it out too for designer perspective. I found [this article](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally) on how to test out changes in PR locally so you can see what the UI currently looks like.

Some questions/TODOs:
- [ ] Change to the right font for the displayed message ("We will send you a link to reset your password!"). Should I add new rules in the `Styles` folder for things like titles, headings, and subtitles?
- [ ] Vertically center the form (including message). Flexbox will probably work, but other recommendations welcome. Should I add rules for vertically centered containers in `Styles` too? It will probably be used a lot.
- [ ] Currently, the `ForgotPassword` component's styles are exactly the same as `Login`. However, it's a bit WET because several styles like `FullPageLayer` and `FullPageFilter` are been repeated. How should I collect these repeated styles to make the CSS more DRY?