### PR TITLE
Removed a unique key warning from Profile Page

### DIFF
--- a/client/src/components/Profile/Component.jsx
+++ b/client/src/components/Profile/Component.jsx
@@ -45,6 +45,7 @@ class Profile extends React.Component {
     return links.map(link => {
       return (
         <GridNavItem
+          key={(Math.random())}
           onClick={() => {
             link.callback(link.text);
           }}
@@ -132,7 +133,7 @@ class Profile extends React.Component {
               <SeeAll>See All ></SeeAll>
               <GridContainer className="scroll">
                 {[1, 3, 42, 4, 2, 4, 2, 4, 2, 3].map(i => {
-                  return <GridItemContainer></GridItemContainer>;
+                  return <GridItemContainer key={(Math.random())}></GridItemContainer>;
                 })}
               </GridContainer>
             </SectionsContainer>


### PR DESCRIPTION
Fixed #30 

I used `Math.random()` to generate an unique key for each element on the map which fixed the error. 